### PR TITLE
fix fetchExperiments error handling

### DIFF
--- a/AppboosterSdk/src/main/java/com/appbooster/appboostersdk/AppboosterHandler.kt
+++ b/AppboosterSdk/src/main/java/com/appbooster/appboostersdk/AppboosterHandler.kt
@@ -24,7 +24,7 @@ internal class AppboosterHandler : Handler(Looper.getMainLooper()) {
     }
 
     internal fun sendError(listener: AppboosterSdk.OnErrorListener, th: Throwable) {
-        obtainMessage(ON_SUCCESS, Result(null, listener, th)).sendToTarget();
+        obtainMessage(ON_ERROR, Result(null, listener, th)).sendToTarget();
     }
 
     class Result(


### PR DESCRIPTION
#### :tophat: Что? Зачем?
Фикс логики обработки ошибок при запросе экспериментов.

**Суть ошибки.** Ранее всегда в `handler`'е отправлялось сообщение `ON_SUCCESS`, даже в случае ошибки. Соответственно, мы всегда пытались вызвать `onSuccessListener`, но в случае ошибки (вызов метода `sendError`) мы не прокидываем `onSuccessListener` в `handler`. В итоге получается, что ни один из листенеров не срабатывает.

**Суть фикса.** Теперь мы при возникновении ошибки (вызов метода `sendError`) шлем сообщение `ON_ERROR` тем самым попадая на вызов метода `onErrorListener`, который мы прокинули в метод `sendError`.